### PR TITLE
Remove unnecessary console log output

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,7 @@ const registerCommandOnFile = (context: vscode.ExtensionContext, gitExtensionsPa
 export function activate(context: vscode.ExtensionContext) {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
-  console.log('Activing "vscode-gitextensions" extension.');
+  // console.log('Activing "vscode-gitextensions" extension.');
 
   const config = vscode.workspace.getConfiguration();
   const gitExtensionsPath = config.get<string>('gitExtensions.exe.path');


### PR DESCRIPTION
Best practice is to avoid unnecessary log pollution.